### PR TITLE
Update verify-music.sh so as it can execute node scripts

### DIFF
--- a/backend/music-schedule/verifier/Readme.txt
+++ b/backend/music-schedule/verifier/Readme.txt
@@ -8,3 +8,8 @@ Usage:
     2. Execute: <path_to_verifier> <run_command>
         - For example, ../verifier/verify-music.sh run.sh
 
+If your app is not an executable file itself (e.g. `.js`) then you can pass a second argument to tell `verify-music.sh` how to execute it.
+E.g.
+```
+../verifier/verify-music.sh my-app.js node
+```

--- a/backend/music-schedule/verifier/verify-music.sh
+++ b/backend/music-schedule/verifier/verify-music.sh
@@ -9,9 +9,15 @@ function verify {
     FILE_PATH="$DIR/$1"
 
     echo ""
-    echo -n "Testing $FILE_PATH.json..."
+    echo "Testing $FILE_PATH.json..."
 
-    bash $EXE $FILE_PATH.json
+    if [ -z "$EXE_USING" ];
+    then
+      bash $EXE ${FILE_PATH}.json
+    else
+      echo "Running: $EXE_USING $EXE ${FILE_PATH}.json"
+      $EXE_USING $EXE ${FILE_PATH}.json
+    fi
 
     if [ $? -ne 0 ]; then
       echo ""
@@ -43,17 +49,24 @@ function normaliseJson {
     jq -c . $1 | jq .
 }
 
-if [ $# -ne 1 ]; then
-    echo "Usage: $0 <path>"
+if [ $# -ne 1 ] && [ $# -ne 2 ]; then
+    echo "Usage: $0 <path> <run_using>"
     echo "  path: Full path to the executable to test"
     echo "        The executable should take two arguments: the input and output file names"
+    echo "  run_using: An optional command used to execute the given path (e.g. node)"
     exit 1
 fi
 
-EXE=$1
+EXE="$1"
+EXE_USING="$2"
 
 rm -f *.optimal.json
 echo "Testing executable '$EXE'"
+
+if [ ! -z "$EXE_USING" ];
+then
+  echo "  with '$EXE_USING'"
+fi
 
 verify "example"
 verify "overlapping"

--- a/backend/music-schedule/verifier/verify-music.sh
+++ b/backend/music-schedule/verifier/verify-music.sh
@@ -11,13 +11,7 @@ function verify {
     echo ""
     echo "Testing $FILE_PATH.json..."
 
-    if [ -z "$EXE_USING" ];
-    then
-      bash $EXE ${FILE_PATH}.json
-    else
-      echo "Running: $EXE_USING $EXE ${FILE_PATH}.json"
-      $EXE_USING $EXE ${FILE_PATH}.json
-    fi
+    $EXE_USING $EXE ${FILE_PATH}.json
 
     if [ $? -ne 0 ]; then
       echo ""
@@ -61,12 +55,13 @@ EXE="$1"
 EXE_USING="$2"
 
 rm -f *.optimal.json
-echo "Testing executable '$EXE'"
 
-if [ ! -z "$EXE_USING" ];
+if [ -z "$EXE_USING" ];
 then
-  echo "  with '$EXE_USING'"
+  EXE_USING="bash"
 fi
+
+echo "Testing executable '$EXE' using '$EXE_USING'"
 
 verify "example"
 verify "overlapping"


### PR DESCRIPTION
`verify-music.sh` isn't set up particularly well to enable custom execution of apps, at least without creation of a custom `run.sh`.

This change aims to make it easier for users to just run their app.

I've updated it to accept a 2nd argument that can be used to execute the app.

Both of the following now work:

```
./verify-music.sh app.exe
./verify-music.sh app.js node
```

This essentially just saves you creating a run script.